### PR TITLE
refactor: Make code in sparse_console idiomatic to remove warnings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,8 @@
         "markdown",
         "latex",
         "plaintext"
+    ],
+    "github-actions.workflows.pinned.workflows": [
+        ".github/workflows/rust.yml"
     ]
 }

--- a/bracket-terminal/src/bterm.rs
+++ b/bracket-terminal/src/bterm.rs
@@ -1,4 +1,4 @@
-#![allow(dead_code)]
+#![allow(clippy::borrowed_box)]
 #[allow(unused_imports)]
 use crate::{
     prelude::{
@@ -21,6 +21,7 @@ pub struct DisplayConsole {
     pub font_index: usize,
 }
 
+#[derive(Default)]
 pub struct BTermInternal {
     pub fonts: Vec<Font>,
     pub shaders: Vec<Shader>,
@@ -30,17 +31,6 @@ pub struct BTermInternal {
 
 impl BTermInternal {
     pub fn new() -> Self {
-        Self {
-            fonts: Vec::new(),
-            shaders: Vec::new(),
-            consoles: Vec::new(),
-            sprite_sheets: Vec::new(),
-        }
-    }
-}
-
-impl Default for BTermInternal {
-    fn default() -> Self {
         Self {
             fonts: Vec::new(),
             shaders: Vec::new(),
@@ -1123,14 +1113,12 @@ pub fn letter_to_option(key: VirtualKeyCode) -> i32 {
     }
 }
 
-// Since num::clamp is still experimental, this is a simple integer clamper.
-fn iclamp(val: i32, min: i32, max: i32) -> i32 {
-    i32::max(min, i32::min(val, max))
-}
-
 #[cfg(test)]
 mod tests {
-    use super::iclamp;
+    // Since num::clamp is still experimental, this is a simple integer clamper.
+    fn iclamp(val: i32, min: i32, max: i32) -> i32 {
+        i32::max(min, i32::min(val, max))
+    }
 
     #[test]
     // Tests that we make an RGB triplet at defaults and it is black.

--- a/bracket-terminal/src/consoles/command_buffer.rs
+++ b/bracket-terminal/src/consoles/command_buffer.rs
@@ -868,19 +868,19 @@ pub fn render_draw_buffer(bterm: &mut BTerm) -> BResult<()> {
                 bterm.set(pos.x, pos.y, color.fg, color.bg, *glyph)
             }
             DrawCommand::SetBackground { pos, bg } => bterm.set_bg(pos.x, pos.y, *bg),
-            DrawCommand::Print { pos, text } => bterm.print(pos.x, pos.y, &text),
+            DrawCommand::Print { pos, text } => bterm.print(pos.x, pos.y, text),
             DrawCommand::PrintColor { pos, text, color } => {
-                bterm.print_color(pos.x, pos.y, color.fg, color.bg, &text)
+                bterm.print_color(pos.x, pos.y, color.fg, color.bg, text)
             }
-            DrawCommand::PrintCentered { y, text } => bterm.print_centered(*y, &text),
+            DrawCommand::PrintCentered { y, text } => bterm.print_centered(*y, text),
             DrawCommand::PrintColorCentered { y, text, color } => {
-                bterm.print_color_centered(*y, color.fg, color.bg, &text)
+                bterm.print_color_centered(*y, color.fg, color.bg, text)
             }
             DrawCommand::PrintCenteredAt { pos, text } => {
-                bterm.print_centered_at(pos.x, pos.y, &text)
+                bterm.print_centered_at(pos.x, pos.y, text)
             }
             DrawCommand::PrintColorCenteredAt { pos, text, color } => {
-                bterm.print_color_centered_at(pos.x, pos.y, color.fg, color.bg, &text)
+                bterm.print_color_centered_at(pos.x, pos.y, color.fg, color.bg, text)
             }
             DrawCommand::PrintRight { pos, text } => bterm.print_right(pos.x, pos.y, text),
             DrawCommand::PrintColorRight { pos, text, color } => {

--- a/bracket-terminal/src/consoles/flexible_console.rs
+++ b/bracket-terminal/src/consoles/flexible_console.rs
@@ -378,7 +378,7 @@ impl Console for FlexiConsole {
         for c in &self.tiles {
             let x = c.position.x as usize;
             let y = c.position.y as usize;
-            let cell = layer.get_mut(x as usize, y as usize).unwrap();
+            let cell = layer.get_mut(x, y).unwrap();
             cell.ch = u32::from(c.glyph);
             cell.fg = XpColor::from(c.fg);
             cell.bg = XpColor::from(c.bg);

--- a/bracket-terminal/src/consoles/sparse_console.rs
+++ b/bracket-terminal/src/consoles/sparse_console.rs
@@ -341,7 +341,7 @@ impl Console for SparseConsole {
         for c in &self.tiles {
             let x = c.idx % self.width as usize;
             let y = c.idx / self.width as usize;
-            let cell = layer.get_mut(x as usize, y as usize).unwrap();
+            let cell = layer.get_mut(x, y).unwrap();
             cell.ch = u32::from(c.glyph);
             cell.fg = c.fg.into();
             cell.bg = c.bg.into();

--- a/bracket-terminal/src/consoles/text/textblock.rs
+++ b/bracket-terminal/src/consoles/text/textblock.rs
@@ -174,7 +174,7 @@ impl TextBlock {
 
                 CommandType::TextWrapper { block: t } => {
                     for word in t.split(' ') {
-                        let mut chrs = string_to_cp437(&word);
+                        let mut chrs = string_to_cp437(word);
                         chrs.push(32);
                         if self.cursor.0 + chrs.len() as i32 >= self.width {
                             self.cursor.0 = 0;
@@ -225,12 +225,12 @@ impl TextBuilder {
     }
 
     pub fn append(&mut self, text: &str) -> &mut Self {
-        let chrs = string_to_cp437(&text);
+        let chrs = string_to_cp437(text);
         self.commands.push(CommandType::Text { block: chrs });
         self
     }
     pub fn centered(&mut self, text: &str) -> &mut Self {
-        let chrs = string_to_cp437(&text);
+        let chrs = string_to_cp437(text);
         self.commands.push(CommandType::Centered { block: chrs });
         self
     }


### PR DESCRIPTION
Make code idiomatic by resolving the clippy warnings or allowing the warning within the scope of the module.

Files addressed include:
- flexible_console.rs
- textblock.rs
- command_buffer.rs
- bterm