### PR TITLE
refactor: Make code in examples distribution to remove warnings

### DIFF
--- a/bracket-random/examples/distribution.rs
+++ b/bracket-random/examples/distribution.rs
@@ -2,10 +2,7 @@ use bracket_random::prelude::*;
 
 fn main() {
     let mut rng = RandomNumberGenerator::new();
-    let mut rolls: Vec<i32> = Vec::new();
-    for _ in 0..=18 {
-        rolls.push(0);
-    }
+    let mut rolls: Vec<i32> = vec![0; 19];
 
     const N_ROLLS: i32 = 200000;
 
@@ -18,12 +15,13 @@ fn main() {
     let max = rolls.iter().max().unwrap();
     let scale = 70.0 / *max as f32;
 
+    #[allow(clippy::needless_range_loop)]
     for i in 3..=18 {
         //println!("{:02} was rolled {} times.", i, rolls[i]);
         print!("{:02} : ", i);
         for _ in 0..(rolls[i] as f32 * scale) as i32 {
             print!("#");
         }
-        println!("");
+        println!();
     }
 }


### PR DESCRIPTION
- replace loop to fill rolls with 0 with vec! macro initialised with 19 zeros.
- remove reduntant string in line feed println!
- allow needless_range_loop as the item would not be used from iterator